### PR TITLE
add default 'all' environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ var go = module.exports =
  * @return {TransformStream} transform stream into which `browserify` will pipe the original content of the file
  */
 function browserifySwap(file) {
-  var env = process.env.BROWSERIFYSWAP_ENV
+  var env = process.env.BROWSERIFYSWAP_ENV || 'all'
     , data = ''
     , swapFile;
 


### PR DESCRIPTION
@thlorenz Regarding #2, i monkey patch-ed to allow 'all' as a default environment.

It is frustrating that all the sources on the web mention this `all` environment default flag but its actually doesn't work.

f.e:
- http://stackoverflow.com/a/29224523/1949274
- https://terinstock.com/blog/2014/02/27/replacing-packages-in-a-browserify-bundle.html
